### PR TITLE
add basic test of executables and support more Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
-        python-version: ["3.6"]
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - dev-ssciwr
   pull_request:
     branches:
       - master
+      - dev-ssciwr
 
 jobs:
   install-and-test:

--- a/pbio/utils/pgrms/create_mygene_report.py
+++ b/pbio/utils/pgrms/create_mygene_report.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 import pbio.utils.mygene_utils as mygene_utils
 import pbio.misc.utils as utils
+import pbio.misc.logging_utils as logging_utils
 import pbio.misc.pandas_utils as pandas_utils
 
 logger = logging.getLogger(__name__)
@@ -49,9 +50,9 @@ def main():
         "is in csv format, then the output will not be compressed. By default, the output "
         "is compressed.", action='store_true')
     
-    utils.add_logging_options(parser)
+    logging_utils.add_logging_options(parser)
     args = parser.parse_args()
-    utils.update_logging(args)
+    logging_utils.update_logging(args)
 
     msg = "Reading the file"
     logger.info(msg)

--- a/pbio/utils/pgrms/extract_cds_coordinates.py
+++ b/pbio/utils/pgrms/extract_cds_coordinates.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python3
 
 import argparse
-import pbio.misc.gffread_utils as gffread_utils
-import pbio.misc.bio as bio
+import pbio.utils.gffread_utils as gffread_utils
+import pbio.utils.bed_utils as bed_utils
 import pandas as pd     
 
 def main():
@@ -32,7 +32,7 @@ def main():
     cds_only_df['score'] = 0
     cds_only_df['strand'] = headers['strand']
 
-    bio.write_bed(cds_only_df, args.out)
+    bed_utils.write_bed(cds_only_df, args.out)
 
 if __name__ == '__main__':
     main()

--- a/pbio/utils/pgrms/get_all_utrs.py
+++ b/pbio/utils/pgrms/get_all_utrs.py
@@ -3,7 +3,7 @@
 import argparse
 
 import pbio.utils.gffread_utils as gffread_utils
-import pbio.misc.utils as utils
+import pbio.misc.logging_utils as logging_utils
 import pbio.misc.pandas_utils as pandas_utils
 
 def main():
@@ -16,9 +16,9 @@ def main():
     parser.add_argument('out', help="The (csv.gz) output file")
 
 
-    utils.add_logging_options(parser)
+    logging_utils.add_logging_options(parser)
     args = parser.parse_args()
-    utils.update_logging(args)
+    logging_utils.update_logging(args)
 
     utr_info = gffread_utils.get_all_utrs(args.transcripts)
 

--- a/pbio/utils/pgrms/join_long_chromosomes.py
+++ b/pbio/utils/pgrms/join_long_chromosomes.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 import pbio.utils.bed_utils as bed_utils
 import pbio.misc.parallel as parallel
-import pbio.misc.utils as utils
+import pbio.misc.logging_utils as logging_utils
 
 default_max_size = 500e6
 default_num_procs = 1
@@ -51,9 +51,9 @@ def main():
     parser.add_argument('--num-procs', help="The number of processors to use", type=int,
         default=default_num_procs)
     
-    utils.add_logging_options(parser)
+    logging_utils.add_logging_options(parser)
     args = parser.parse_args()
-    utils.update_logging(args)
+    logging_utils.update_logging(args)
    
     msg = "Reading BED"
     logging.info(msg)

--- a/pbio/utils/pgrms/reorder_fasta.py
+++ b/pbio/utils/pgrms/reorder_fasta.py
@@ -6,7 +6,7 @@ import textwrap
 
 import tqdm
 
-import pbio.utils.star_utils as star_utils
+import pbio.utils.pgrm_utils as pgrm_utils
 import pbio.utils.fastx_utils as fastx_utils
 import pbio.misc.logging_utils as logging_utils
 
@@ -29,7 +29,7 @@ def main():
 
     msg = "Reading STAR transcript file"
     logging.info(msg)
-    transcript_info = star_utils.read_star_tr_file(args.transcript_info)
+    transcript_info = pgrm_utils.read_star_tr_file(args.transcript_info)
 
     msg = "Reading transcript fasta file"
     logging.info(msg)

--- a/pbio/utils/pgrms/split_long_chromosomes.py
+++ b/pbio/utils/pgrms/split_long_chromosomes.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 import pbio.utils.bio as bio
 import pbio.utils.gtf_utils as gtf_utils
-import pbio.misc.utils as utils
+import pbio.misc.logging_utils as logging_utils
 
 import argparse
 
@@ -29,9 +29,9 @@ def main():
     parser.add_argument('--max-size', help="The largest allowed size (in bp) for a "
         "chromosome", type=int, default=default_max_size)
     
-    utils.add_logging_options(parser)
+    logging_utils.add_logging_options(parser)
     args = parser.parse_args()
-    utils.update_logging(args)
+    logging_utils.update_logging(args)
 
     msg = "Splitting fasta sequences"
     logging.info(msg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,13 @@ install_requires =
     matplotlib
     matplotlib_venn
     seaborn
-python_requires = >=3.6,<3.7.0a0
+    pysam
+    pybedtools
+    Bio
+    pyensembl
+    pystan <3
+
+python_requires = >=3.6,<3.10.0a0
 include_package_data = True
 zip_safe = False
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,22 @@
+import pytest
+import subprocess
+
+
+@pytest.fixture
+def list_commands():
+    return ["bam-to-wiggle", "bedx-to-bedy", "bed-to-bigBed", "bed12-to-gtf",
+            "calculate-bed-overlap", "convert-ccds-to-bed", "count-aligned-reads",
+            "count-reads", "create-aligned-read-count-bar-chart", "create-mygene-report",
+            "create-init-ribo-track", "dna-to-aa", "download-srr-files", "extract-bed-sequences",
+            "extract-cds-coordinates", "fasta-to-fastq", "fastq-pe-dedupe", "filter-bam-by-ids",
+            "fix-all-bed-files", "get-all-utrs", "get-read-length-distribution", "gtf-to-bed12",
+            "join-long-chromosomes", "merge-isoforms", "parse-meme-names", "plot-read-length-distribution",
+            "remove-duplicate-bed-entries", "remove-duplicate-sequences", "remove-multimapping-reads",
+            "reorder-fasta", "run-bowtie", "run-signalp", "run-tmhmm", "split-bed12-blocks",
+            "split-long-chromosomes", "subtract-bed", "extract-metagene-profiles",
+            "estimate-metagene-profile-bayes-factors", "select-periodic-offsets", "pickle-stan",]
+
+
+def test_commands_help_arg(list_commands):
+    for command in list_commands:
+        assert subprocess.run([command, "--help"]).returncode == 0


### PR DESCRIPTION
- allow python versions 3.6-3.9 in setup.cfg
- add CI jobs to test all combinations of:
  - os: ubuntu, macos
  - python: 3.6, 3.7, 3.8, 3.9
- skip python 3.10 for now (not supported by pystan2 - but is supported by pystan 3)
- not testing windows in CI (not supported by pystan)
- add a test that calls each executable with the argument `--help`
- fix broken imports & add missing dependencies so that these tests pass