### PR TITLE
add PyPI deployment CI job

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,25 @@
+name: PyPI
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  pypi:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: pip install --upgrade build
+      - name: Install pybio-utils including test dependencies
+        run: pip install .[test] --verbose
+      - name: Run tests
+        run: python -m pytest . -v
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - - started 2022-07
 
-We are working on a major version upgrade. 
+We are working on a major version upgrade.
 
 ### Changed
+
 - `pbio` to `pbiotools`
 
 ### Added
-- GitHub CI workflow
 
+- GitHub CI workflow
 
 ## [1.0.0] - 2019-10-26
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,8 @@
 name = pbiotools
 description = "Miscellaneous bioinformatics and other supporting utilities for Python 3"
 long-description = file: README.md
-version = 1.0.0
+long_description_content_type = text/markdown
+version = attr: pbiotools.__version__
 url = https://github.com/dieterich-lab/pbiotools
 author = Brandon Malone
 maintainer = Etienne Boileau


### PR DESCRIPTION
- runs when a commit is tagged with a version number of the form x.y.z
- builds wheel and uploads release to PyPI
- needs `pypi_token` in repository secrets to authenticate to PyPI

setup.cfg improvements

- add missing `long_description_content_type` to setup.cfg
- get version from `pbiotools.__version__` instead of duplicating it in setup.cfg